### PR TITLE
Add missed epigraph

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -215,7 +215,9 @@
 		<item href="text/chapter-5-3.xhtml" id="chapter-5-3.xhtml" media-type="application/xhtml+xml"/>
 		<item href="text/colophon.xhtml" id="colophon.xhtml" media-type="application/xhtml+xml" properties="svg"/>
 		<item href="text/endnotes.xhtml" id="endnotes.xhtml" media-type="application/xhtml+xml"/>
+		<item href="text/epigraph.xhtml" id="epigraph.xhtml" media-type="application/xhtml+xml"/>
 		<item href="text/epilogue.xhtml" id="epilogue.xhtml" media-type="application/xhtml+xml"/>
+		<item href="text/halftitle.xhtml" id="halftitle.xhtml" media-type="application/xhtml+xml"/>
 		<item href="text/imprint.xhtml" id="imprint.xhtml" media-type="application/xhtml+xml" properties="svg"/>
 		<item href="text/part-1.xhtml" id="part-1.xhtml" media-type="application/xhtml+xml"/>
 		<item href="text/part-2.xhtml" id="part-2.xhtml" media-type="application/xhtml+xml"/>
@@ -227,6 +229,8 @@
 	<spine>
 		<itemref idref="titlepage.xhtml"/>
 		<itemref idref="imprint.xhtml"/>
+		<itemref idref="epigraph.xhtml"/>
+		<itemref idref="halftitle.xhtml"/>
 		<itemref idref="part-1.xhtml"/>
 		<itemref idref="book-1.xhtml"/>
 		<itemref idref="chapter-1-1-1.xhtml"/>

--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -46,3 +46,47 @@ footer{
 [epub|type~="z3998:song"] p > span + br{
 	display: none;
 }
+
+/* All epigraphs */
+[epub|type~="epigraph"]{
+	font-style: italic;
+	hyphens: none;
+	-epub-hyphens: none;
+}
+
+[epub|type~="epigraph"] cite{
+	margin-top: 1em;
+	font-style: normal;
+	font-variant: small-caps;
+}
+/* End all epigraphs */
+
+/* Full-page epigraphs */
+section[epub|type~="epigraph"]{
+	text-align: center;
+}
+
+section[epub|type~="epigraph"] > *{
+	display: inline-block;
+	margin: auto;
+	margin-top: 3em;
+	max-width: 80%;
+	text-align: left;
+}
+
+@supports(display: flex){
+	section[epub|type~="epigraph"]{
+		align-items: center;
+		box-sizing: border-box;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		min-height: calc(98vh - 3em);
+		padding-top: 3em;
+	}
+
+	section[epub|type~="epigraph"] > *{
+		margin: 0;
+	}
+}
+/* End full-page epigraphs */

--- a/src/epub/text/epigraph.xhtml
+++ b/src/epub/text/epigraph.xhtml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
+	<head>
+		<title>Epigraph</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="frontmatter">
+		<section id="epigraph" epub:type="epigraph">
+			<blockquote>
+				<p>Verily, verily, I say unto you, Except a corn of wheat fall into the ground and die, it abideth alone: but, if it die, it bringeth forth much fruit.</p>
+				<cite>John, <span epub:type="z3998:roman">xii</span> 24</cite>
+			</blockquote>
+		</section>
+	</body>
+</html>

--- a/src/epub/text/halftitle.xhtml
+++ b/src/epub/text/halftitle.xhtml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" epub:prefix="z3998: http://www.daisy.org/z3998/2012/vocab/structure/, se: https://standardebooks.org/vocab/1.0" xml:lang="en-US">
+	<head>
+		<title>The Brothers Karamazov</title>
+		<link href="../css/core.css" rel="stylesheet" type="text/css"/>
+		<link href="../css/local.css" rel="stylesheet" type="text/css"/>
+	</head>
+	<body epub:type="frontmatter">
+		<section id="halftitlepage" epub:type="halftitlepage">
+			<h1 epub:type="fulltitle">The Brothers Karamazov</h1>
+		</section>
+	</body>
+</html>

--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -14,375 +14,383 @@
 					<a href="text/imprint.xhtml">Imprint</a>
 				</li>
 				<li>
-					<a href="text/part-1.xhtml">Part <span epub:type="z3998:roman">I</span></a>
-					<ol>
-						<li>
-							<a href="text/book-1.xhtml">Book <span epub:type="z3998:roman">I</span>: The History of a Family</a>
-							<ol>
-								<li>
-									<a href="text/chapter-1-1-1.xhtml"><span epub:type="z3998:roman">I</span>: Fyodor Pavlovitch Karamazov</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-1-2.xhtml"><span epub:type="z3998:roman">II</span>: He Gets Rid of His Eldest Son</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-1-3.xhtml"><span epub:type="z3998:roman">III</span>: The Second Marriage and the Second Family</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-1-4.xhtml"><span epub:type="z3998:roman">IV</span>: The Third Son, Alyosha</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-1-5.xhtml"><span epub:type="z3998:roman">V</span>: Elders</a>
-								</li>
-							</ol>
-						</li>
-						<li>
-							<a href="text/book-2.xhtml">Book <span epub:type="z3998:roman">II</span>: An Unfortunate Gathering</a>
-							<ol>
-								<li>
-									<a href="text/chapter-1-2-1.xhtml"><span epub:type="z3998:roman">I</span>: They Arrive at the Monastery</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-2-2.xhtml"><span epub:type="z3998:roman">II</span>: The Old Buffoon</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-2-3.xhtml"><span epub:type="z3998:roman">III</span>: Peasant Women Who Have Faith</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-2-4.xhtml"><span epub:type="z3998:roman">IV</span>: A Lady of Little Faith</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-2-5.xhtml"><span epub:type="z3998:roman">V</span>: So Be It! So Be It!</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-2-6.xhtml"><span epub:type="z3998:roman">VI</span>: Why Is Such a Man Alive?</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-2-7.xhtml"><span epub:type="z3998:roman">VII</span>: A Young Man Bent on a Career</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-2-8.xhtml"><span epub:type="z3998:roman">VIII</span>: The Scandalous Scene</a>
-								</li>
-							</ol>
-						</li>
-						<li>
-							<a href="text/book-3.xhtml">Book <span epub:type="z3998:roman">III</span>: The Sensualists</a>
-							<ol>
-								<li>
-									<a href="text/chapter-1-3-1.xhtml"><span epub:type="z3998:roman">I</span>: In the Servants’ Quarters</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-3-2.xhtml"><span epub:type="z3998:roman">II</span>: Lizaveta</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-3-3.xhtml"><span epub:type="z3998:roman">III</span>: The Confession of a Passionate Heart—In Verse</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-3-4.xhtml"><span epub:type="z3998:roman">IV</span>: The Confession of a Passionate Heart—In Anecdote</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-3-5.xhtml"><span epub:type="z3998:roman">V</span>: The Confession of a Passionate Heart—“Heels Up”</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-3-6.xhtml"><span epub:type="z3998:roman">VI</span>: Smerdyakov</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-3-7.xhtml"><span epub:type="z3998:roman">VII</span>: The Controversy</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-3-8.xhtml"><span epub:type="z3998:roman">VIII</span>: Over the Brandy</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-3-9.xhtml"><span epub:type="z3998:roman">IX</span>: The Sensualists</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-3-10.xhtml"><span epub:type="z3998:roman">X</span>: Both Together</a>
-								</li>
-								<li>
-									<a href="text/chapter-1-3-11.xhtml"><span epub:type="z3998:roman">XI</span>: Another Reputation Ruined</a>
-								</li>
-							</ol>
-						</li>
-					</ol>
+					<a href="text/epigraph.xhtml">Epigraph</a>
 				</li>
 				<li>
-					<a href="text/part-2.xhtml">Part <span epub:type="z3998:roman">II</span></a>
+					<a href="text/halftitle.xhtml">The Brothers Karamazov</a>
 					<ol>
 						<li>
-							<a href="text/book-4.xhtml">Book <span epub:type="z3998:roman">IV</span>: Lacerations</a>
+							<a href="text/part-1.xhtml">Part <span epub:type="z3998:roman">I</span></a>
 							<ol>
 								<li>
-									<a href="text/chapter-2-4-1.xhtml"><span epub:type="z3998:roman">I</span>: Father Ferapont</a>
+									<a href="text/book-1.xhtml">Book <span epub:type="z3998:roman">I</span>: The History of a Family</a>
+									<ol>
+										<li>
+											<a href="text/chapter-1-1-1.xhtml"><span epub:type="z3998:roman">I</span>: Fyodor Pavlovitch Karamazov</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-1-2.xhtml"><span epub:type="z3998:roman">II</span>: He Gets Rid of His Eldest Son</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-1-3.xhtml"><span epub:type="z3998:roman">III</span>: The Second Marriage and the Second Family</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-1-4.xhtml"><span epub:type="z3998:roman">IV</span>: The Third Son, Alyosha</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-1-5.xhtml"><span epub:type="z3998:roman">V</span>: Elders</a>
+										</li>
+									</ol>
 								</li>
 								<li>
-									<a href="text/chapter-2-4-2.xhtml"><span epub:type="z3998:roman">II</span>: At His Father’s</a>
+									<a href="text/book-2.xhtml">Book <span epub:type="z3998:roman">II</span>: An Unfortunate Gathering</a>
+									<ol>
+										<li>
+											<a href="text/chapter-1-2-1.xhtml"><span epub:type="z3998:roman">I</span>: They Arrive at the Monastery</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-2-2.xhtml"><span epub:type="z3998:roman">II</span>: The Old Buffoon</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-2-3.xhtml"><span epub:type="z3998:roman">III</span>: Peasant Women Who Have Faith</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-2-4.xhtml"><span epub:type="z3998:roman">IV</span>: A Lady of Little Faith</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-2-5.xhtml"><span epub:type="z3998:roman">V</span>: So Be It! So Be It!</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-2-6.xhtml"><span epub:type="z3998:roman">VI</span>: Why Is Such a Man Alive?</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-2-7.xhtml"><span epub:type="z3998:roman">VII</span>: A Young Man Bent on a Career</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-2-8.xhtml"><span epub:type="z3998:roman">VIII</span>: The Scandalous Scene</a>
+										</li>
+									</ol>
 								</li>
 								<li>
-									<a href="text/chapter-2-4-3.xhtml"><span epub:type="z3998:roman">III</span>: A Meeting with the Schoolboys</a>
-								</li>
-								<li>
-									<a href="text/chapter-2-4-4.xhtml"><span epub:type="z3998:roman">IV</span>: At the Hohlakovs’</a>
-								</li>
-								<li>
-									<a href="text/chapter-2-4-5.xhtml"><span epub:type="z3998:roman">V</span>: A Laceration in the Drawing-Room</a>
-								</li>
-								<li>
-									<a href="text/chapter-2-4-6.xhtml"><span epub:type="z3998:roman">VI</span>: A Laceration in the Cottage</a>
-								</li>
-								<li>
-									<a href="text/chapter-2-4-7.xhtml"><span epub:type="z3998:roman">VII</span>: And in the Open Air</a>
+									<a href="text/book-3.xhtml">Book <span epub:type="z3998:roman">III</span>: The Sensualists</a>
+									<ol>
+										<li>
+											<a href="text/chapter-1-3-1.xhtml"><span epub:type="z3998:roman">I</span>: In the Servants’ Quarters</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-3-2.xhtml"><span epub:type="z3998:roman">II</span>: Lizaveta</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-3-3.xhtml"><span epub:type="z3998:roman">III</span>: The Confession of a Passionate Heart—In Verse</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-3-4.xhtml"><span epub:type="z3998:roman">IV</span>: The Confession of a Passionate Heart—In Anecdote</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-3-5.xhtml"><span epub:type="z3998:roman">V</span>: The Confession of a Passionate Heart—“Heels Up”</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-3-6.xhtml"><span epub:type="z3998:roman">VI</span>: Smerdyakov</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-3-7.xhtml"><span epub:type="z3998:roman">VII</span>: The Controversy</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-3-8.xhtml"><span epub:type="z3998:roman">VIII</span>: Over the Brandy</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-3-9.xhtml"><span epub:type="z3998:roman">IX</span>: The Sensualists</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-3-10.xhtml"><span epub:type="z3998:roman">X</span>: Both Together</a>
+										</li>
+										<li>
+											<a href="text/chapter-1-3-11.xhtml"><span epub:type="z3998:roman">XI</span>: Another Reputation Ruined</a>
+										</li>
+									</ol>
 								</li>
 							</ol>
 						</li>
 						<li>
-							<a href="text/book-5.xhtml">Book <span epub:type="z3998:roman">V</span>: Pro and Contra</a>
+							<a href="text/part-2.xhtml">Part <span epub:type="z3998:roman">II</span></a>
 							<ol>
 								<li>
-									<a href="text/chapter-2-5-1.xhtml"><span epub:type="z3998:roman">I</span>: The Engagement</a>
+									<a href="text/book-4.xhtml">Book <span epub:type="z3998:roman">IV</span>: Lacerations</a>
+									<ol>
+										<li>
+											<a href="text/chapter-2-4-1.xhtml"><span epub:type="z3998:roman">I</span>: Father Ferapont</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-4-2.xhtml"><span epub:type="z3998:roman">II</span>: At His Father’s</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-4-3.xhtml"><span epub:type="z3998:roman">III</span>: A Meeting with the Schoolboys</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-4-4.xhtml"><span epub:type="z3998:roman">IV</span>: At the Hohlakovs’</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-4-5.xhtml"><span epub:type="z3998:roman">V</span>: A Laceration in the Drawing-Room</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-4-6.xhtml"><span epub:type="z3998:roman">VI</span>: A Laceration in the Cottage</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-4-7.xhtml"><span epub:type="z3998:roman">VII</span>: And in the Open Air</a>
+										</li>
+									</ol>
 								</li>
 								<li>
-									<a href="text/chapter-2-5-2.xhtml"><span epub:type="z3998:roman">II</span>: Smerdyakov with a Guitar</a>
+									<a href="text/book-5.xhtml">Book <span epub:type="z3998:roman">V</span>: Pro and Contra</a>
+									<ol>
+										<li>
+											<a href="text/chapter-2-5-1.xhtml"><span epub:type="z3998:roman">I</span>: The Engagement</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-5-2.xhtml"><span epub:type="z3998:roman">II</span>: Smerdyakov with a Guitar</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-5-3.xhtml"><span epub:type="z3998:roman">III</span>: The Brothers Make Friends</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-5-4.xhtml"><span epub:type="z3998:roman">IV</span>: Rebellion</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-5-5.xhtml"><span epub:type="z3998:roman">V</span>: The Grand Inquisitor</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-5-6.xhtml"><span epub:type="z3998:roman">VI</span>: For Awhile a Very Obscure One</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-5-7.xhtml"><span epub:type="z3998:roman">VII</span>: “It’s Always Worth While Speaking to a Clever Man”</a>
+										</li>
+									</ol>
 								</li>
 								<li>
-									<a href="text/chapter-2-5-3.xhtml"><span epub:type="z3998:roman">III</span>: The Brothers Make Friends</a>
-								</li>
-								<li>
-									<a href="text/chapter-2-5-4.xhtml"><span epub:type="z3998:roman">IV</span>: Rebellion</a>
-								</li>
-								<li>
-									<a href="text/chapter-2-5-5.xhtml"><span epub:type="z3998:roman">V</span>: The Grand Inquisitor</a>
-								</li>
-								<li>
-									<a href="text/chapter-2-5-6.xhtml"><span epub:type="z3998:roman">VI</span>: For Awhile a Very Obscure One</a>
-								</li>
-								<li>
-									<a href="text/chapter-2-5-7.xhtml"><span epub:type="z3998:roman">VII</span>: “It’s Always Worth While Speaking to a Clever Man”</a>
+									<a href="text/book-6.xhtml">Book <span epub:type="z3998:roman">VI</span>: The Russian Monk</a>
+									<ol>
+										<li>
+											<a href="text/chapter-2-6-1.xhtml"><span epub:type="z3998:roman">I</span>: Father Zossima and His Visitors</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-6-2.xhtml"><span epub:type="z3998:roman">II</span>: The Duel</a>
+										</li>
+										<li>
+											<a href="text/chapter-2-6-3.xhtml"><span epub:type="z3998:roman">III</span>: Conversations and Exhortations of Father Zossima</a>
+										</li>
+									</ol>
 								</li>
 							</ol>
 						</li>
 						<li>
-							<a href="text/book-6.xhtml">Book <span epub:type="z3998:roman">VI</span>: The Russian Monk</a>
+							<a href="text/part-3.xhtml">Part <span epub:type="z3998:roman">III</span></a>
 							<ol>
 								<li>
-									<a href="text/chapter-2-6-1.xhtml"><span epub:type="z3998:roman">I</span>: Father Zossima and His Visitors</a>
+									<a href="text/book-7.xhtml">Book <span epub:type="z3998:roman">VII</span>: Alyosha</a>
+									<ol>
+										<li>
+											<a href="text/chapter-3-7-1.xhtml"><span epub:type="z3998:roman">I</span>: The Breath of Corruption</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-7-2.xhtml"><span epub:type="z3998:roman">II</span>: A Critical Moment</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-7-3.xhtml"><span epub:type="z3998:roman">III</span>: An Onion</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-7-4.xhtml"><span epub:type="z3998:roman">IV</span>: Cana of Galilee</a>
+										</li>
+									</ol>
 								</li>
 								<li>
-									<a href="text/chapter-2-6-2.xhtml"><span epub:type="z3998:roman">II</span>: The Duel</a>
+									<a href="text/book-8.xhtml">Book <span epub:type="z3998:roman">VIII</span>: Mitya</a>
+									<ol>
+										<li>
+											<a href="text/chapter-3-8-1.xhtml"><span epub:type="z3998:roman">I</span>: Kuzma Samsonov</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-8-2.xhtml"><span epub:type="z3998:roman">II</span>: Lyagavy</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-8-3.xhtml"><span epub:type="z3998:roman">III</span>: Goldmines</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-8-4.xhtml"><span epub:type="z3998:roman">IV</span>: In the Dark</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-8-5.xhtml"><span epub:type="z3998:roman">V</span>: A Sudden Resolution</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-8-6.xhtml"><span epub:type="z3998:roman">VI</span>: “I Am Coming, Too!”</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-8-7.xhtml"><span epub:type="z3998:roman">VII</span>: The First and Rightful Lover</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-8-8.xhtml"><span epub:type="z3998:roman">VIII</span>: Delirium</a>
+										</li>
+									</ol>
 								</li>
 								<li>
-									<a href="text/chapter-2-6-3.xhtml"><span epub:type="z3998:roman">III</span>: Conversations and Exhortations of Father Zossima</a>
-								</li>
-							</ol>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/part-3.xhtml">Part <span epub:type="z3998:roman">III</span></a>
-					<ol>
-						<li>
-							<a href="text/book-7.xhtml">Book <span epub:type="z3998:roman">VII</span>: Alyosha</a>
-							<ol>
-								<li>
-									<a href="text/chapter-3-7-1.xhtml"><span epub:type="z3998:roman">I</span>: The Breath of Corruption</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-7-2.xhtml"><span epub:type="z3998:roman">II</span>: A Critical Moment</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-7-3.xhtml"><span epub:type="z3998:roman">III</span>: An Onion</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-7-4.xhtml"><span epub:type="z3998:roman">IV</span>: Cana of Galilee</a>
-								</li>
-							</ol>
-						</li>
-						<li>
-							<a href="text/book-8.xhtml">Book <span epub:type="z3998:roman">VIII</span>: Mitya</a>
-							<ol>
-								<li>
-									<a href="text/chapter-3-8-1.xhtml"><span epub:type="z3998:roman">I</span>: Kuzma Samsonov</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-8-2.xhtml"><span epub:type="z3998:roman">II</span>: Lyagavy</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-8-3.xhtml"><span epub:type="z3998:roman">III</span>: Goldmines</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-8-4.xhtml"><span epub:type="z3998:roman">IV</span>: In the Dark</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-8-5.xhtml"><span epub:type="z3998:roman">V</span>: A Sudden Resolution</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-8-6.xhtml"><span epub:type="z3998:roman">VI</span>: “I Am Coming, Too!”</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-8-7.xhtml"><span epub:type="z3998:roman">VII</span>: The First and Rightful Lover</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-8-8.xhtml"><span epub:type="z3998:roman">VIII</span>: Delirium</a>
-								</li>
-							</ol>
-						</li>
-						<li>
-							<a href="text/book-9.xhtml">Book <span epub:type="z3998:roman">IX</span>: The Preliminary Investigation</a>
-							<ol>
-								<li>
-									<a href="text/chapter-3-9-1.xhtml"><span epub:type="z3998:roman">I</span>: The Beginning of Perhotin’s Official Career</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-9-2.xhtml"><span epub:type="z3998:roman">II</span>: The Alarm</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-9-3.xhtml"><span epub:type="z3998:roman">III</span>: The Sufferings of a Soul, the First Ordeal</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-9-4.xhtml"><span epub:type="z3998:roman">IV</span>: The Second Ordeal</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-9-5.xhtml"><span epub:type="z3998:roman">V</span>: The Third Ordeal</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-9-6.xhtml"><span epub:type="z3998:roman">VI</span>: The Prosecutor Catches Mitya</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-9-7.xhtml"><span epub:type="z3998:roman">VII</span>: Mitya’s Great Secret. Received with Hisses</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-9-8.xhtml"><span epub:type="z3998:roman">VIII</span>: The Evidence of the Witnesses. The Babe</a>
-								</li>
-								<li>
-									<a href="text/chapter-3-9-9.xhtml"><span epub:type="z3998:roman">IX</span>: They Carry Mitya Away</a>
-								</li>
-							</ol>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/part-4.xhtml">Part <span epub:type="z3998:roman">IV</span></a>
-					<ol>
-						<li>
-							<a href="text/book-10.xhtml">Book <span epub:type="z3998:roman">X</span>: The Boys</a>
-							<ol>
-								<li>
-									<a href="text/chapter-4-10-1.xhtml"><span epub:type="z3998:roman">I</span>: Kolya Krassotkin</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-10-2.xhtml"><span epub:type="z3998:roman">II</span>: Children</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-10-3.xhtml"><span epub:type="z3998:roman">III</span>: The Schoolboy</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-10-4.xhtml"><span epub:type="z3998:roman">IV</span>: The Lost Dog</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-10-5.xhtml"><span epub:type="z3998:roman">V</span>: By Ilusha’s Bedside</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-10-6.xhtml"><span epub:type="z3998:roman">VI</span>: Precocity</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-10-7.xhtml"><span epub:type="z3998:roman">VII</span>: Ilusha</a>
+									<a href="text/book-9.xhtml">Book <span epub:type="z3998:roman">IX</span>: The Preliminary Investigation</a>
+									<ol>
+										<li>
+											<a href="text/chapter-3-9-1.xhtml"><span epub:type="z3998:roman">I</span>: The Beginning of Perhotin’s Official Career</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-9-2.xhtml"><span epub:type="z3998:roman">II</span>: The Alarm</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-9-3.xhtml"><span epub:type="z3998:roman">III</span>: The Sufferings of a Soul, the First Ordeal</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-9-4.xhtml"><span epub:type="z3998:roman">IV</span>: The Second Ordeal</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-9-5.xhtml"><span epub:type="z3998:roman">V</span>: The Third Ordeal</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-9-6.xhtml"><span epub:type="z3998:roman">VI</span>: The Prosecutor Catches Mitya</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-9-7.xhtml"><span epub:type="z3998:roman">VII</span>: Mitya’s Great Secret. Received with Hisses</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-9-8.xhtml"><span epub:type="z3998:roman">VIII</span>: The Evidence of the Witnesses. The Babe</a>
+										</li>
+										<li>
+											<a href="text/chapter-3-9-9.xhtml"><span epub:type="z3998:roman">IX</span>: They Carry Mitya Away</a>
+										</li>
+									</ol>
 								</li>
 							</ol>
 						</li>
 						<li>
-							<a href="text/book-11.xhtml">Book <span epub:type="z3998:roman">XI</span>: Ivan</a>
+							<a href="text/part-4.xhtml">Part <span epub:type="z3998:roman">IV</span></a>
 							<ol>
 								<li>
-									<a href="text/chapter-4-11-1.xhtml"><span epub:type="z3998:roman">I</span>: At Grushenka’s</a>
+									<a href="text/book-10.xhtml">Book <span epub:type="z3998:roman">X</span>: The Boys</a>
+									<ol>
+										<li>
+											<a href="text/chapter-4-10-1.xhtml"><span epub:type="z3998:roman">I</span>: Kolya Krassotkin</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-10-2.xhtml"><span epub:type="z3998:roman">II</span>: Children</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-10-3.xhtml"><span epub:type="z3998:roman">III</span>: The Schoolboy</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-10-4.xhtml"><span epub:type="z3998:roman">IV</span>: The Lost Dog</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-10-5.xhtml"><span epub:type="z3998:roman">V</span>: By Ilusha’s Bedside</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-10-6.xhtml"><span epub:type="z3998:roman">VI</span>: Precocity</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-10-7.xhtml"><span epub:type="z3998:roman">VII</span>: Ilusha</a>
+										</li>
+									</ol>
 								</li>
 								<li>
-									<a href="text/chapter-4-11-2.xhtml"><span epub:type="z3998:roman">II</span>: The Injured Foot</a>
+									<a href="text/book-11.xhtml">Book <span epub:type="z3998:roman">XI</span>: Ivan</a>
+									<ol>
+										<li>
+											<a href="text/chapter-4-11-1.xhtml"><span epub:type="z3998:roman">I</span>: At Grushenka’s</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-11-2.xhtml"><span epub:type="z3998:roman">II</span>: The Injured Foot</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-11-3.xhtml"><span epub:type="z3998:roman">III</span>: A Little Demon</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-11-4.xhtml"><span epub:type="z3998:roman">IV</span>: A Hymn and a Secret</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-11-5.xhtml"><span epub:type="z3998:roman">V</span>: Not You, Not You!</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-11-6.xhtml"><span epub:type="z3998:roman">VI</span>: The First Interview with Smerdyakov</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-11-7.xhtml"><span epub:type="z3998:roman">VII</span>: The Second Visit to Smerdyakov</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-11-8.xhtml"><span epub:type="z3998:roman">VIII</span>: The Third and Last Interview with Smerdyakov</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-11-9.xhtml"><span epub:type="z3998:roman">IX</span>: The Devil. Ivan’s Nightmare</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-11-10.xhtml"><span epub:type="z3998:roman">X</span>: “It Was He Who Said That”</a>
+										</li>
+									</ol>
 								</li>
 								<li>
-									<a href="text/chapter-4-11-3.xhtml"><span epub:type="z3998:roman">III</span>: A Little Demon</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-11-4.xhtml"><span epub:type="z3998:roman">IV</span>: A Hymn and a Secret</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-11-5.xhtml"><span epub:type="z3998:roman">V</span>: Not You, Not You!</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-11-6.xhtml"><span epub:type="z3998:roman">VI</span>: The First Interview with Smerdyakov</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-11-7.xhtml"><span epub:type="z3998:roman">VII</span>: The Second Visit to Smerdyakov</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-11-8.xhtml"><span epub:type="z3998:roman">VIII</span>: The Third and Last Interview with Smerdyakov</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-11-9.xhtml"><span epub:type="z3998:roman">IX</span>: The Devil. Ivan’s Nightmare</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-11-10.xhtml"><span epub:type="z3998:roman">X</span>: “It Was He Who Said That”</a>
+									<a href="text/book-12.xhtml">Book <span epub:type="z3998:roman">XII</span>: A Judicial Error</a>
+									<ol>
+										<li>
+											<a href="text/chapter-4-12-1.xhtml"><span epub:type="z3998:roman">I</span>: The Fatal Day</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-12-2.xhtml"><span epub:type="z3998:roman">II</span>: Dangerous Witnesses</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-12-3.xhtml"><span epub:type="z3998:roman">III</span>: The Medical Experts and a Pound of Nuts</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-12-4.xhtml"><span epub:type="z3998:roman">IV</span>: Fortune Smiles on Mitya</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-12-5.xhtml"><span epub:type="z3998:roman">V</span>: A Sudden Catastrophe</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-12-6.xhtml"><span epub:type="z3998:roman">VI</span>: The Prosecutor’s Speech. Sketches of Character</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-12-7.xhtml"><span epub:type="z3998:roman">VII</span>: An Historical Survey</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-12-8.xhtml"><span epub:type="z3998:roman">VIII</span>: A Treatise on Smerdyakov</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-12-9.xhtml"><span epub:type="z3998:roman">IX</span>: The Galloping Troika. The End of the Prosecutor’s Speech</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-12-10.xhtml"><span epub:type="z3998:roman">X</span>: The Speech for the Defense. An Argument That Cuts Both Ways</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-12-11.xhtml"><span epub:type="z3998:roman">XI</span>: There Was No Money. There Was No Robbery</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-12-12.xhtml"><span epub:type="z3998:roman">XII</span>: And There Was No Murder Either</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-12-13.xhtml"><span epub:type="z3998:roman">XIII</span>: A Corrupter of Thought</a>
+										</li>
+										<li>
+											<a href="text/chapter-4-12-14.xhtml"><span epub:type="z3998:roman">XIV</span>: The Peasants Stand Firm</a>
+										</li>
+									</ol>
 								</li>
 							</ol>
 						</li>
 						<li>
-							<a href="text/book-12.xhtml">Book <span epub:type="z3998:roman">XII</span>: A Judicial Error</a>
+							<a href="text/epilogue.xhtml">Epilogue</a>
 							<ol>
 								<li>
-									<a href="text/chapter-4-12-1.xhtml"><span epub:type="z3998:roman">I</span>: The Fatal Day</a>
+									<a href="text/chapter-5-1.xhtml"><span epub:type="z3998:roman">I</span>: Plans for Mitya’s Escape</a>
 								</li>
 								<li>
-									<a href="text/chapter-4-12-2.xhtml"><span epub:type="z3998:roman">II</span>: Dangerous Witnesses</a>
+									<a href="text/chapter-5-2.xhtml"><span epub:type="z3998:roman">II</span>: For a Moment the Lie Becomes Truth</a>
 								</li>
 								<li>
-									<a href="text/chapter-4-12-3.xhtml"><span epub:type="z3998:roman">III</span>: The Medical Experts and a Pound of Nuts</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-12-4.xhtml"><span epub:type="z3998:roman">IV</span>: Fortune Smiles on Mitya</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-12-5.xhtml"><span epub:type="z3998:roman">V</span>: A Sudden Catastrophe</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-12-6.xhtml"><span epub:type="z3998:roman">VI</span>: The Prosecutor’s Speech. Sketches of Character</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-12-7.xhtml"><span epub:type="z3998:roman">VII</span>: An Historical Survey</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-12-8.xhtml"><span epub:type="z3998:roman">VIII</span>: A Treatise on Smerdyakov</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-12-9.xhtml"><span epub:type="z3998:roman">IX</span>: The Galloping Troika. The End of the Prosecutor’s Speech</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-12-10.xhtml"><span epub:type="z3998:roman">X</span>: The Speech for the Defense. An Argument That Cuts Both Ways</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-12-11.xhtml"><span epub:type="z3998:roman">XI</span>: There Was No Money. There Was No Robbery</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-12-12.xhtml"><span epub:type="z3998:roman">XII</span>: And There Was No Murder Either</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-12-13.xhtml"><span epub:type="z3998:roman">XIII</span>: A Corrupter of Thought</a>
-								</li>
-								<li>
-									<a href="text/chapter-4-12-14.xhtml"><span epub:type="z3998:roman">XIV</span>: The Peasants Stand Firm</a>
+									<a href="text/chapter-5-3.xhtml"><span epub:type="z3998:roman">III</span>: Ilusha’s Funeral. The Speech at the Stone</a>
 								</li>
 							</ol>
-						</li>
-					</ol>
-				</li>
-				<li>
-					<a href="text/epilogue.xhtml">Epilogue</a>
-					<ol>
-						<li>
-							<a href="text/chapter-5-1.xhtml"><span epub:type="z3998:roman">I</span>: Plans for Mitya’s Escape</a>
-						</li>
-						<li>
-							<a href="text/chapter-5-2.xhtml"><span epub:type="z3998:roman">II</span>: For a Moment the Lie Becomes Truth</a>
-						</li>
-						<li>
-							<a href="text/chapter-5-3.xhtml"><span epub:type="z3998:roman">III</span>: Ilusha’s Funeral. The Speech at the Stone</a>
 						</li>
 					</ol>
 				</li>
@@ -405,6 +413,12 @@
 				</li>
 				<li>
 					<a href="text/imprint.xhtml" epub:type="frontmatter imprint">Imprint</a>
+				</li>
+				<li>
+					<a href="text/epigraph.xhtml" epub:type="frontmatter epigraph">Epigraph</a>
+				</li>
+				<li>
+					<a href="text/halftitle.xhtml" epub:type="frontmatter halftitlepage">Half Title</a>
 				</li>
 				<li>
 					<a href="text/part-1.xhtml" epub:type="bodymatter z3998:fiction">The Brothers Karamazov</a>


### PR DESCRIPTION
It wasn’t in the Gutenberg transcription, and was hidden on the copyright page in the scans. Thanks to John Herald for pointing this out.